### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitbybit",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitbybit",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@getalby/sdk": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbybit",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump `package.json` and `package-lock.json` version from `0.1.0` to `1.0.0` to match the [v1.0.0 release](https://github.com/bitbybit-ar/bitbybit-habits/releases/tag/v1.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)