### PR TITLE
feat: centralize session with SessionProvider

### DIFF
--- a/app/[locale]/(dashboard)/preview/page.tsx
+++ b/app/[locale]/(dashboard)/preview/page.tsx
@@ -2,27 +2,24 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "@/i18n/routing";
+import { useSessionContext } from "@/lib/session-context";
 import { Onboarding } from "@/components/dashboard/onboarding";
 import styles from "../dashboard.module.scss";
 
 export default function OnboardingPreview() {
   const [dismissed, setDismissed] = useState(false);
   const router = useRouter();
+  const { session, isLoading, refreshSession } = useSessionContext();
+
+  // Refresh session when dismissed, then redirect based on result
+  useEffect(() => {
+    if (dismissed) void refreshSession();
+  }, [dismissed, refreshSession]);
 
   useEffect(() => {
-    if (!dismissed) return;
-
-    async function checkSession() {
-      const res = await fetch("/api/auth/session");
-      const data = await res.json();
-      if (data.success && data.data) {
-        router.push("/dashboard");
-      } else {
-        router.push("/login");
-      }
-    }
-    checkSession();
-  }, [dismissed, router]);
+    if (!dismissed || isLoading) return;
+    router.push(session ? "/dashboard" : "/login");
+  }, [dismissed, isLoading, session, router]);
 
   return (
     <div className={styles.container}>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import Footer from "@/components/layout/footer";
 import { SwRegister } from "@/components/sw-register";
 import { ToastProvider } from "@/components/ui/toast";
 import { ThemeProvider } from "@/lib/theme-context";
+import { SessionProvider } from "@/lib/session-context";
 import { StructuredData } from "@/components/seo/structured-data";
 import "@/styles/globals.scss";
 
@@ -109,17 +110,19 @@ export default async function LocaleLayout({
       <body className={`${nunito.variable} ${nunitoSans.variable}`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider>
-            <ToastProvider>
-              <a href="#main-content" className="skip-link">
-                {messages && typeof messages === "object" && "accessibility" in messages
-                  ? (messages.accessibility as Record<string, string>).skipToContent
-                  : "Skip to content"}
-              </a>
-              <Navbar />
-              <SwRegister />
-              <main id="main-content">{children}</main>
-              <Footer />
-            </ToastProvider>
+            <SessionProvider>
+              <ToastProvider>
+                <a href="#main-content" className="skip-link">
+                  {messages && typeof messages === "object" && "accessibility" in messages
+                    ? (messages.accessibility as Record<string, string>).skipToContent
+                    : "Skip to content"}
+                </a>
+                <Navbar />
+                <SwRegister />
+                <main id="main-content">{children}</main>
+                <Footer />
+              </ToastProvider>
+            </SessionProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/components/layout/navbar/index.tsx
+++ b/components/layout/navbar/index.tsx
@@ -13,53 +13,24 @@ import {
 import { NotificationBell } from "@/components/dashboard/notification-bell";
 import { LanguageSwitcher } from "@/components/layout/language-switcher";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
+import { useSessionContext } from "@/lib/session-context";
 import styles from "./navbar.module.scss";
 import { cn } from "@/lib/utils";
-
-interface NavbarUser {
-  user_id: string;
-  display_name?: string;
-  role?: string | null;
-}
 
 export const Navbar: React.FC = () => {
   const t = useTranslations();
   const pathname = usePathname();
   const router = useRouter();
+  const { session: user, isLoading: sessionLoading, refreshSession, clearSession } = useSessionContext();
   const [visible, setVisible] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
   const [scrollProgress, setScrollProgress] = useState(0);
-  const [user, setUser] = useState<NavbarUser | null>(null);
-  const [checkedSession, setCheckedSession] = useState(false);
 
   const isLanding = /^\/(es|en)?\/?$/.test(pathname);
   const isLoginPage = /^\/(es|en)\/login\/?$/.test(pathname);
   const isRegisterPage = /^\/(es|en)\/register\/?$/.test(pathname);
+  const checkedSession = !sessionLoading;
   const isLoggedIn = !!user;
-
-  // Fetch session on mount and on route changes (login/logout navigates)
-  useEffect(() => {
-    let cancelled = false;
-
-    fetch("/api/auth/session", { cache: "no-store" })
-      .then((res) => (res.ok ? res.json() : { success: false }))
-      .then((data) => {
-        if (!cancelled) {
-          setUser(data.success ? data.data : null);
-          setCheckedSession(true);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setUser(null);
-          setCheckedSession(true);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [pathname]);
 
   const LANDING_LINKS = [
     { href: "#how-it-works", label: t("landing.nav.howItWorks") },
@@ -104,14 +75,15 @@ export const Navbar: React.FC = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, [isLanding, closeMenu]);
 
-  // Close mobile menu on route change
+  // Refresh session + close mobile menu on route change
   useEffect(() => {
     closeMenu();
-  }, [pathname, closeMenu]);
+    void refreshSession();
+  }, [pathname, closeMenu, refreshSession]);
 
   const handleLogout = async () => {
     await fetch("/api/auth/logout", { method: "POST" });
-    setUser(null);
+    clearSession();
     router.push("/");
   };
 

--- a/lib/hooks/useSession.ts
+++ b/lib/hooks/useSession.ts
@@ -1,8 +1,31 @@
 "use client";
 
-import { useApi } from "./useApi";
+import { useSessionContext } from "@/lib/session-context";
 import type { AuthSession } from "@/lib/types";
 
-export function useSession() {
-  return useApi<AuthSession | null>("/api/auth/session", null);
+interface UseSessionResult {
+  data: AuthSession | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  setData: React.Dispatch<React.SetStateAction<AuthSession | null>>;
+}
+
+/**
+ * Hook that returns the shared session from SessionProvider.
+ * Preserves the same interface as the old useApi-based hook
+ * so existing consumers (kid/sponsor dashboards) work unchanged.
+ */
+export function useSession(): UseSessionResult {
+  const { session, isLoading, refreshSession } = useSessionContext();
+
+  return {
+    data: session,
+    isLoading,
+    error: null,
+    refetch: refreshSession,
+    // setData is a no-op — session state is owned by the provider.
+    // Callers that need to update session should call refetch() instead.
+    setData: () => {},
+  };
 }

--- a/lib/session-context.tsx
+++ b/lib/session-context.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from "react";
+import type { AuthSession } from "./types";
+
+interface SessionContextValue {
+  session: AuthSession | null;
+  isLoading: boolean;
+  refreshSession: () => Promise<void>;
+  clearSession: () => void;
+}
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchSession = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/auth/session", {
+        signal: controller.signal,
+        cache: "no-store",
+      });
+      if (controller.signal.aborted) return;
+      if (res.ok) {
+        const json = await res.json();
+        setSession(json.success ? json.data : null);
+      } else {
+        setSession(null);
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      if (!controller.signal.aborted) setSession(null);
+    } finally {
+      if (!controller.signal.aborted) setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSession();
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [fetchSession]);
+
+  const clearSession = useCallback(() => {
+    setSession(null);
+  }, []);
+
+  return (
+    <SessionContext.Provider
+      value={{ session, isLoading, refreshSession: fetchSession, clearSession }}
+    >
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSessionContext(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) {
+    throw new Error("useSessionContext must be used within a SessionProvider");
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- Add `SessionProvider` (React Context) that fetches `/api/auth/session` once and shares state across all consumers
- Replace independent session fetches in Navbar, kid/sponsor dashboards, and preview page with the shared context
- Navbar calls `refreshSession()` on route changes and `clearSession()` on logout

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] All 208 tests pass (verified)
- [ ] Login → verify Navbar updates immediately (no duplicate fetch)
- [ ] Navigate between kid/sponsor tabs → session shared, no extra API calls
- [ ] Logout → Navbar clears instantly, redirects to landing
- [ ] Preview page → dismiss onboarding → redirects based on session

🤖 Generated with [Claude Code](https://claude.com/claude-code)